### PR TITLE
Add Selenium example with Mobitru

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ package-lock.json
 # Compiled
 dist
 __snapshots__
+
+.env

--- a/example-selenium/.env.example
+++ b/example-selenium/.env.example
@@ -1,0 +1,10 @@
+# Mobitru settings
+BROWSER_PROVIDER=mobitru
+MOBITRU_BILLING_UNIT=personal
+MOBITRU_ACCESS_TOKEN=your_access_token
+# MOBITRU_HUB_URL=browserhub-us.mobitru.com
+
+# ReportPortal settings
+RP_PROJECT=your_project
+RP_ENDPOINT=your_endpoint
+RP_API_KEY=your_api_key

--- a/example-selenium/README.md
+++ b/example-selenium/README.md
@@ -1,0 +1,104 @@
+## Example for [@reportportal/agent-js-mocha](https://www.npmjs.com/package/@reportportal/agent-js-mocha) with Selenium WebDriver
+
+Selenium WebDriver examples for Chrome that report results to ReportPortal via the Mocha agent. Tests can run locally or on [Mobitru](https://mobitru.com/) cloud browsers.
+
+## Prerequisites
+
+- Node.js
+- Google Chrome browser installed locally (for local runs only)
+
+ChromeDriver is resolved automatically by [Selenium Manager](https://www.selenium.dev/documentation/selenium_manager/) (built into `selenium-webdriver` v4) when running tests locally.
+
+## Configuration
+
+Copy `.env.example` to `.env` and fill in the required values:
+
+```cmd
+cp .env.example .env
+```
+
+### Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `RP_ENDPOINT` | Yes | ReportPortal API endpoint, e.g. `https://your-instance.com/api/v1` |
+| `RP_API_KEY` | Yes | ReportPortal API key |
+| `RP_PROJECT` | Yes | ReportPortal project name |
+| `BROWSER_PROVIDER` | No | Browser provider: `local` (default) or `mobitru` |
+| `MOBITRU_BILLING_UNIT` | For Mobitru | Team identifier or `personal` for individual accounts |
+| `MOBITRU_ACCESS_TOKEN` | For Mobitru | Mobitru access key |
+| `MOBITRU_HUB_URL` | No | Mobitru hub host (default: `browserhub-us.mobitru.com`) |
+| `HEADLESS` | No | Set to `false` to run local Chrome in headed mode |
+
+Example `.env`:
+
+```env
+# ReportPortal settings
+RP_PROJECT=your_project
+RP_ENDPOINT=https://your-instance.com/api/v1
+RP_API_KEY=your_api_key
+
+# Mobitru settings (only required when BROWSER_PROVIDER=mobitru)
+BROWSER_PROVIDER=mobitru
+MOBITRU_BILLING_UNIT=personal
+MOBITRU_ACCESS_TOKEN=your_access_token
+# MOBITRU_HUB_URL=browserhub-us.mobitru.com
+```
+
+ReportPortal options are read from `.env` in `main.js`:
+
+```javascript
+reporterOptions: {
+  endpoint: process.env.RP_ENDPOINT,
+  apiKey: process.env.RP_API_KEY,
+  project: process.env.RP_PROJECT,
+}
+```
+
+## Run test example
+
+Install the packages:
+
+```cmd
+npm install
+```
+
+### Local Chrome
+
+Make sure `BROWSER_PROVIDER` is not set to `mobitru` in `.env` (or remove it to use the default local provider).
+
+```cmd
+npm test
+```
+
+To run tests in headed mode (with a visible browser window):
+
+```cmd
+HEADLESS=false npm test
+```
+
+### Mobitru cloud browser
+
+Configure Mobitru credentials as described in the [Mobitru Selenium initial configuration](https://mobitru.com/docs/initial-configuration-selenium/) docs and set `BROWSER_PROVIDER=mobitru` in `.env`.
+
+Run tests against Mobitru with video recording enabled:
+
+```cmd
+npm run test:mobitru
+```
+
+The driver connects to `https://${MOBITRU_BILLING_UNIT}:${MOBITRU_ACCESS_TOKEN}@browserhub-us.mobitru.com/wd/hub` and passes `mobitru:options.enableVideo: true` so session video is recorded on the Mobitru side.
+
+The Mobitru session ID is stored in the `mobitru_selenium_recording_id` test attribute via `driver.getSession().getId()` and can be used to download the recording after the session ends. See [Mobitru video recording](https://mobitru.com/docs/video-recording-2/) for details.
+
+## Tests
+
+- `tests/google.spec.js` — opens Google, verifies the page title, and sends a screenshot to ReportPortal
+- `tests/example-domain.spec.js` — opens example.com, verifies the main heading, and sends a screenshot to ReportPortal
+
+## Browser providers
+
+| Provider | Env variable | Description |
+|----------|--------------|-------------|
+| Local    | default      | Headless Chrome on the local machine |
+| Mobitru  | `BROWSER_PROVIDER=mobitru` | Remote Chrome on Mobitru with video recording |

--- a/example-selenium/main.js
+++ b/example-selenium/main.js
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2026 EPAM Systems
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+require('dotenv').config();
+
+const Mocha = require('mocha');
+
+const mochaMain = new Mocha({
+  reporter: '@reportportal/agent-js-mocha',
+  reporterOptions: {
+    endpoint: process.env.RP_ENDPOINT,
+    apiKey: process.env.RP_API_KEY,
+    launch: 'Mocha tests for Selenium with Mobitru',
+    project: process.env.RP_PROJECT,
+  },
+  timeout: 250000,
+});
+
+try {
+  mochaMain.files = ['tests/google.spec.js', 'tests/example-domain.spec.js'];
+  mochaMain.run((failures) => process.on('exit', () => process.exit(failures)));
+} catch (err) {
+  console.error(`Test suite doesn't exists or set. Error: ${err}`);
+}

--- a/example-selenium/package.json
+++ b/example-selenium/package.json
@@ -1,0 +1,15 @@
+{
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "node main.js",
+    "test:mobitru": "cross-env BROWSER_PROVIDER=mobitru node main.js"
+  },
+  "devDependencies": {
+    "@reportportal/agent-js-mocha": "^5.1.0",
+    "chai": "^4.5.0",
+    "cross-env": "^7.0.3",
+    "dotenv": "^16.4.7",
+    "mocha": "^10.7.0",
+    "selenium-webdriver": "^4.27.0"
+  }
+}

--- a/example-selenium/tests/driver.js
+++ b/example-selenium/tests/driver.js
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2026 EPAM Systems
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+const { Builder, Browser } = require('selenium-webdriver');
+const chrome = require('selenium-webdriver/chrome');
+
+const MOBITRU_HUB_URL = process.env.MOBITRU_HUB_URL || 'browserhub-us.mobitru.com';
+
+function isMobitruEnabled() {
+  return process.env.BROWSER_PROVIDER === 'mobitru';
+}
+
+function getBrowserProvider() {
+  return isMobitruEnabled() ? 'mobitru' : 'local';
+}
+
+async function createMobitruDriver() {
+  const billingUnit = process.env.MOBITRU_BILLING_UNIT;
+  const accessToken = process.env.MOBITRU_ACCESS_TOKEN;
+
+  if (!billingUnit || !accessToken) {
+    throw new Error(
+      'MOBITRU_BILLING_UNIT and MOBITRU_ACCESS_TOKEN environment variables are required when BROWSER_PROVIDER=mobitru',
+    );
+  }
+
+  const mobitruOptions = {
+    'mobitru:options': {
+      enableVideo: true,
+    },
+  };
+
+  return new Builder()
+    .withCapabilities(mobitruOptions)
+    .forBrowser(Browser.CHROME)
+    .usingServer(`https://${billingUnit}:${accessToken}@${MOBITRU_HUB_URL}/wd/hub`)
+    .build();
+}
+
+async function createLocalDriver() {
+  const options = new chrome.Options();
+
+  if (process.env.HEADLESS !== 'false') {
+    options.addArguments('--headless=new');
+  }
+
+  options.addArguments('--no-sandbox', '--disable-dev-shm-usage');
+
+  return new Builder().forBrowser('chrome').setChromeOptions(options).build();
+}
+
+async function createDriver() {
+  if (isMobitruEnabled()) {
+    return createMobitruDriver();
+  }
+
+  return createLocalDriver();
+}
+
+async function getMobitruRecordingId(driver) {
+  const session = await driver.getSession();
+
+  return session.getId();
+}
+
+module.exports = { createDriver, getBrowserProvider, getMobitruRecordingId, isMobitruEnabled };

--- a/example-selenium/tests/example-domain.spec.js
+++ b/example-selenium/tests/example-domain.spec.js
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2026 EPAM Systems
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+const { expect } = require('chai');
+const { By } = require('selenium-webdriver');
+const PublicReportingAPI = require('@reportportal/agent-js-mocha/lib/publicReportingAPI');
+const { createDriver, getBrowserProvider, getMobitruRecordingId, isMobitruEnabled } = require('./driver');
+
+describe('Example Domain page', function () {
+  this.timeout(30000);
+
+  let driver;
+
+  before(async () => {
+    PublicReportingAPI.setDescription('Selenium test suite for example.com');
+    driver = await createDriver();
+  });
+
+  after(async () => {
+    if (driver) {
+      await driver.quit();
+    }
+  });
+
+  it('should display the Example Domain heading', async () => {
+    PublicReportingAPI.setDescription('Opens example.com and verifies the main heading');
+    const attributes = [
+      { key: 'browser', value: 'chrome' },
+      { key: 'provider', value: getBrowserProvider() },
+    ];
+
+    if (isMobitruEnabled()) {
+      attributes.push({
+        key: 'mobitru_selenium_recording_id',
+        value: await getMobitruRecordingId(driver),
+      });
+    }
+
+    PublicReportingAPI.addAttributes(attributes);
+
+    await driver.get('https://example.com');
+    const heading = await driver.findElement(By.css('h1'));
+    const text = await heading.getText();
+    const screenshot = await driver.takeScreenshot();
+
+    PublicReportingAPI.info('Example Domain page screenshot', {
+      name: 'example-domain.png',
+      type: 'image/png',
+      content: screenshot,
+    });
+
+    expect(text).to.equal('Example Domain');
+  });
+});

--- a/example-selenium/tests/google.spec.js
+++ b/example-selenium/tests/google.spec.js
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2026 EPAM Systems
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+const { expect } = require('chai');
+const PublicReportingAPI = require('@reportportal/agent-js-mocha/lib/publicReportingAPI');
+const { createDriver, getBrowserProvider, getMobitruRecordingId, isMobitruEnabled } = require('./driver');
+
+describe('Google page', function () {
+  this.timeout(30000);
+
+  let driver;
+
+  before(async () => {
+    PublicReportingAPI.setDescription('Selenium test suite for the Google homepage');
+    driver = await createDriver();
+  });
+
+  after(async () => {
+    if (driver) {
+      await driver.quit();
+    }
+  });
+
+  it('should display the Google title', async () => {
+    PublicReportingAPI.setDescription('Opens Google and verifies the page title');
+    const attributes = [
+      { key: 'browser', value: 'chrome' },
+      { key: 'provider', value: getBrowserProvider() },
+    ];
+
+    if (isMobitruEnabled()) {
+      attributes.push({
+        key: 'mobitru_selenium_recording_id',
+        value: await getMobitruRecordingId(driver),
+      });
+    }
+
+    PublicReportingAPI.addAttributes(attributes);
+
+    await driver.get('https://www.google.com');
+    const title = await driver.getTitle();
+    const screenshot = await driver.takeScreenshot();
+
+    PublicReportingAPI.info('Google page screenshot', {
+      name: 'google.png',
+      type: 'image/png',
+      content: screenshot,
+    });
+
+    expect(title).to.include('Google');
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete Selenium testing example for Chrome, supporting both local execution and Mobitru cloud browsers.
  * Added automated Google and Example Domain tests with screenshots and ReportPortal reporting.
  * Added commands for running tests locally or through Mobitru.

* **Documentation**
  * Added setup instructions, configuration examples, prerequisites, test details, and browser-provider guidance.

* **Chores**
  * Added environment configuration templates and protected local environment files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->